### PR TITLE
issue#3/ user削除とteam編集の権限付与

### DIFF
--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -10,7 +10,9 @@
               <%= image_tag default_img(@team.icon_url), class: 'img' %><br>
               <%= @team.name %>
             </div>
+            <% if (current_user ==  @team.owner) %>
             <%= link_to I18n.t('views.messages.edit_team'), edit_team_path(@team), class: 'btn btn-success btn-block mt-3' %>
+            <% end %> 
           </div>
 
           <div class="col-md-8">
@@ -41,7 +43,9 @@
                     <tr>
                       <td><%= image_tag 'default.jpg', size: '40x40' %></td>
                       <td><%= assign.user.email %>/<%= assign.user_id %></td>
+                      <% if current_user.id == @team.owner_id || current_user.id == assign.user_id %>
                       <td><%= link_to I18n.t('views.button.delete'), team_assign_path(@team, assign), method: :delete, class: 'btn btn-sm btn-danger' %></td>
+                      <% end %> 
                       <% if (current_user == @team.owner) && (current_user != assign.user) %>
                       <td><%= link_to '権限移動', change_owner_team_path(@team.id, assign_user_id: assign.user.id), method:  :patch, class: 'btn btn-sm btn-warning' %></td>
                       <% end %>


### PR DESCRIPTION
#3 
## チーム情報の操作に関しての機能を整えること

Teamに所属しているUserの削除（離脱）は、そのTeamのオーナーか、そのUser自身しかできないようにすること
TeamのeditはTeamのリーダー（オーナー）のみができるようにすること
という仕様に変更すること